### PR TITLE
Retarget cohort guidance toward attendees

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,18 +522,18 @@
       <section class="intro-grid" aria-label="How to use this gallery">
         <article class="intro-card">
           <p class="subtle">Cohort framing</p>
-          <h2>Set the stage for learners</h2>
-          <p>Open with a shared definition of prioritization. Invite students to notice how each dashboard balances transparency, outcomes, and feasibility.</p>
+          <h2>Set the stage for your exploration</h2>
+          <p>Ground yourself in a shared definition of prioritization. Notice how each dashboard balances transparency, outcomes, and feasibility as you browse.</p>
           <ul>
-            <li><strong>Start with purpose:</strong> Who needs this dashboard and what question are they answering?</li>
-            <li><strong>Spot context cues:</strong> Navigation, legends, and copy explain the story.</li>
+            <li><strong>Start with purpose:</strong> Consider who relies on each dashboard and the questions it helps them answer.</li>
+            <li><strong>Spot context cues:</strong> Let navigation, legends, and copy guide the narrative.</li>
           </ul>
         </article>
 
         <article class="intro-card">
           <p class="subtle">Guided critique</p>
           <h2>Compare design decisions</h2>
-          <p>Use Compare Mode to pick two dashboards. Prompt students to analyze encoding choices, accessibility, and how prioritization scores are justified.</p>
+          <p>Use Compare Mode to line up two dashboards. Evaluate how encoding choices, accessibility details, and prioritization scores earn your trust.</p>
           <ul>
             <li><strong>What changes:</strong> Layouts shift between matrices, bubbles, and tables.</li>
             <li><strong>What stays consistent:</strong> Color, hierarchy, and language reinforce rankings.</li>
@@ -543,10 +543,10 @@
         <article class="intro-card">
           <p class="subtle">Workshop prompts</p>
           <h2>Move from insight to action</h2>
-          <p>Turn inspiration into a sketching exercise. Ask teams to remix a dashboard pattern for an Austin department challenge.</p>
+          <p>Channel inspiration into a sketching session. Remix a dashboard pattern to tackle an Austin department challenge.</p>
           <ul>
-            <li><strong>Define inputs:</strong> Criteria weights, scoring formulas, and data freshness.</li>
-            <li><strong>Design for delivery:</strong> How would stakeholders explore, annotate, or export decisions?</li>
+            <li><strong>Define inputs:</strong> Choose criteria weights, scoring formulas, and refresh cadences that fit your scenario.</li>
+            <li><strong>Design for delivery:</strong> Plan how stakeholders will explore, annotate, or export their decisions.</li>
           </ul>
         </article>
       </section>


### PR DESCRIPTION
## Summary
- update cohort guidance cards to speak directly to visiting participants
- encourage attendees to evaluate dashboards and plan actionable workshop steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e32173b9ac8320852113db3a2e21a9